### PR TITLE
Update brace-expansion dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-gXz4v7dxyufohadmTJY8C8xcU93+ingazlxmH0hltPOTTfrJ1wtd4gZw339OpeIF18/JIiogECTboleQ3YlLkg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2169,7 +2169,7 @@
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"


### PR DESCRIPTION
## Summary
- bump `brace-expansion` in `frontend/package-lock.json`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685ac9503000832ca9e64c45ff688bcc